### PR TITLE
Fixed step_definition search

### DIFF
--- a/lib/cuke_sniffer/cli.rb
+++ b/lib/cuke_sniffer/cli.rb
@@ -4,10 +4,10 @@ require 'cuke_sniffer/constants'
 module CukeSniffer
   class CLI
     include CukeSniffer::Constants
-    
+
     attr_accessor :features, :step_definitions, :summary
 
-    def initialize(features_location = Dir.getwd, step_definitions_location = Dir.getwd)
+    def initialize(features_location = Dir.getwd, step_definitions_location = Dir.getwd + '/step_definition')
       @features_location = features_location
       @step_definitions_location = step_definitions_location
       @features = []
@@ -30,7 +30,7 @@ module CukeSniffer
         if File.file?(step_definitions_location)
           @step_definitions = [build_step_definitions(step_definitions_location)]
         else
-          build_file_list_from_folder(step_definitions_location, "steps.rb").each { |location|
+          build_file_list_from_folder(step_definitions_location, ".rb").each { |location|
             @step_definitions << build_step_definitions(location)
             print '.'
           }


### PR DESCRIPTION
1. LOC 10 cli.rb : step_definitions_location defaults to Dir.getwd + 'step_definitions'. Correct me if I am wrong, but unless specifically detailed this is the default dir for all step definitions.
2. LOC 33 cli.rb : removed the *steps.rb requirement to allow for other file names.
