### PR TITLE
Fixed gemspec file

### DIFF
--- a/cuke_sniffer.gemspec
+++ b/cuke_sniffer.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |s|
              "lib/cuke_sniffer/rule_config.rb",
              "lib/cuke_sniffer/scenario.rb",
              "lib/cuke_sniffer/step_definition.rb",
-             "lib/cuke_sniffer/report/markup.js",
-             "lib/cuke_sniffer/report/markup.css",
              "lib/cuke_sniffer/report/markup.html.erb",
              "lib/cuke_sniffer/cli.rb",
              "lib/cuke_sniffer/hook.rb",


### PR DESCRIPTION
After cloning I tried to run 'gem build cuke_sniffer.gemspec' but received errors related to a css and js file that no longer exist in the project. Looking through previous commits it appears those files were broken out from the erb file and then put back in but the gemspec wasn't updated. 
