### PR TITLE
Issue 73

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,8 @@ GEM
       multi_json (~> 1.7.5)
       multi_test (>= 0.0.2)
     diff-lcs (1.2.4)
+    gherkin (2.12.1)
+      multi_json (~> 1.3)
     gherkin (2.12.1-x86-mingw32)
       multi_json (~> 1.3)
     i18n (0.6.4)
@@ -29,6 +31,8 @@ GEM
     minitest (4.7.5)
     multi_json (1.7.9)
     multi_test (0.0.2)
+    nokogiri (1.6.0)
+      mini_portile (~> 0.5.0)
     nokogiri (1.6.0-x86-mingw32)
       mini_portile (~> 0.5.0)
     rake (10.1.0)
@@ -48,6 +52,7 @@ GEM
     tzinfo (0.3.37)
 
 PLATFORMS
+  ruby
   x86-mingw32
 
 DEPENDENCIES

--- a/lib/cuke_sniffer/report/dead_steps.html.erb
+++ b/lib/cuke_sniffer/report/dead_steps.html.erb
@@ -23,9 +23,9 @@
         <% index = 0 %>
         <% dead_steps.each_key do |file_name| %>
             <% if index.odd? %>
-                <tr class="notes blue_title_row" onclick="updateDisplayStatus(document.getElementById('dead_step_file_detail_<%=index%>')); updateDivScroll('dead_steps_data', 'dead_steps_table');">
+                <tr class="notes blue_title_row toggleable">
             <% else %>
-                <tr class="notes white_title_row" onclick="updateDisplayStatus(document.getElementById('dead_step_file_detail_<%=index%>')); updateDivScroll('dead_steps_data', 'dead_steps_table');">
+                <tr class="notes white_title_row toggleable">
             <% end %>
               <td class="red_number" style="width: 1%"><%= dead_steps[file_name].size %></td>
               <td id="dead_step_file_<%= index %>">

--- a/lib/cuke_sniffer/report/dead_steps.html.erb
+++ b/lib/cuke_sniffer/report/dead_steps.html.erb
@@ -31,7 +31,7 @@
               <td id="dead_step_file_<%= index %>">
                 <%= file_name.gsub(cuke_sniffer.step_definitions_location, "") %>
               </td>
-              <td style="text-align: right; width:5%" valign="top">
+              <td style="text-align: right; width:5%" valign="top" onclick='preventPropagation(event)'>
                 <a href="file:///<%= file_name.gsub(/:\d+$/, "") %>.rb" title="Note: Links to file on system this report was generated.">
                   (open file)
                 </a>

--- a/lib/cuke_sniffer/report/features.html.erb
+++ b/lib/cuke_sniffer/report/features.html.erb
@@ -35,9 +35,9 @@
           </td>
         </tr>
         <% if index.odd? %>
-            <tr id="feature_detail_<%= index %>" class="blue_row feature_detail" style="display:none;">
+            <tr id="feature_detail_<%= index %>" class="blue_row feature_detail" style="display: none;">
         <% else %>
-            <tr id="feature_detail_<%= index %>" class="white_row feature_detail" style="display:none;">
+            <tr id="feature_detail_<%= index %>" class="white_row feature_detail" style="display: none;">
         <% end %>
 
           <td colspan="2">

--- a/lib/cuke_sniffer/report/features.html.erb
+++ b/lib/cuke_sniffer/report/features.html.erb
@@ -19,9 +19,9 @@
     <% cuke_sniffer.features.each do |feature| %>
         <% next if feature.total_score == 0 %>
         <% if index.odd? %>
-            <tr class="notes blue_title_row" style="cursor: hand;" onclick="updateDisplayStatus(document.getElementById('feature_detail_<%=index%>'));updateDivScroll('features_data', 'features_table');">
+            <tr class="notes blue_title_row toggleable" style="cursor: hand;">
         <% else %>
-            <tr class="notes white_title_row" style="cursor: hand;" onclick="updateDisplayStatus(document.getElementById('feature_detail_<%=index%>'));updateDivScroll('features_data', 'features_table');">
+            <tr class="notes white_title_row toggleable" style="cursor: hand;">
         <% end %>
           <td valign="top" class="red_number" style="width:1%">
             <%= feature.total_score %>

--- a/lib/cuke_sniffer/report/hooks.html.erb
+++ b/lib/cuke_sniffer/report/hooks.html.erb
@@ -44,7 +44,6 @@
             <% name += parameters unless parameters == "|  |" %>
             <%= name %>
           </td>
-          </td>
         </tr>
 
         <% if index.odd? %>

--- a/lib/cuke_sniffer/report/hooks.html.erb
+++ b/lib/cuke_sniffer/report/hooks.html.erb
@@ -18,9 +18,9 @@
     <% cuke_sniffer.hooks.each do |hook| %>
         <% next if hook.score <= 0 %>
         <% if index.odd? %>
-            <tr class="notes blue_title_row" onclick="updateDisplayStatus(document.getElementById('hook_detail_<%=index%>'));updateDivScroll('hooks_data', 'hooks_table');">
+            <tr class="notes blue_title_row toggleable">
         <% else %>
-            <tr class="notes white_title_row" onclick="updateDisplayStatus(document.getElementById('hook_detail_<%=index%>'));updateDivScroll('hooks_data', 'hooks_table');">
+            <tr class="notes white_title_row toggleable">
         <% end %>
           <td id="hook_score_<%= index %>" valign="top" style="width:1%; color: red">
             <%= hook.score %>

--- a/lib/cuke_sniffer/report/js.html.erb
+++ b/lib/cuke_sniffer/report/js.html.erb
@@ -62,26 +62,32 @@
     }
 
     function setToggleIds() {
-      var collapsibleToggleRows = document.getElementsByClassName('toggleable');
-      var onclickString = "updateDisplayStatus(getElementById('%elementId%'));updateDivScroll('%divId%', '%tableId%');"
+        var collapsibleToggleRows = document.getElementsByClassName('toggleable');
+        var onclickString = "updateDisplayStatus(getElementById('%elementId%'));updateDivScroll('%divId%', '%tableId%');"
 
-      for (var i = 0; i < collapsibleToggleRows.length; i++) {
-        toggleRow = collapsibleToggleRows[i];
+        for (var i = 0; i < collapsibleToggleRows.length; i++) {
+            toggleRow = collapsibleToggleRows[i];
 
-        var table = toggleRow.parentNode;
-        console.log(toggleRow);
-        console.log(table);
-        var detailRowId = table.rows[ toggleRow.rowIndex + 1 ].id,
-        tableId = table.id,
-        divId = table.parentNode.id;
+            var table = toggleRow.parentNode;
 
-        var onclickEvent = onclickString.replace('%elementId%', detailRowId).
-        replace('%tableId%', tableId).
-        replace('%divId%', divId);
+            var detailRowId = table.rows[ toggleRow.rowIndex + 1 ].id,
+                tableId = table.id,
+                divId = table.parentNode.id;
 
-        toggleRow.setAttribute('onclick', onclickEvent);
+            var onclickEvent = onclickString.replace('%elementId%', detailRowId).
+                               replace('%tableId%', tableId).
+                               replace('%divId%', divId);
+
+            toggleRow.setAttribute('onclick', onclickEvent);
       }
     }
     setToggleIds();
+
+    function preventPropagation(event) {
+        if (!event) event = window.event;
+
+        event.cancelBubble = true; // IE method
+        if (event.stopPropagation) event.stopPropagation(); // Rest of the world method
+    }
 
 </script>

--- a/lib/cuke_sniffer/report/js.html.erb
+++ b/lib/cuke_sniffer/report/js.html.erb
@@ -61,5 +61,27 @@
         link.innerHTML = link.innerHTML.replace(/(\+|\-)/, char_result)
     }
 
+    function setToggleIds() {
+      var collapsibleToggleRows = document.getElementsByClassName('toggleable');
+      var onclickString = "updateDisplayStatus(getElementById('%elementId%'));updateDivScroll('%divId%', '%tableId%');"
+
+      for (var i = 0; i < collapsibleToggleRows.length; i++) {
+        toggleRow = collapsibleToggleRows[i];
+
+        var table = toggleRow.parentNode;
+        console.log(toggleRow);
+        console.log(table);
+        var detailRowId = table.rows[ toggleRow.rowIndex + 1 ].id,
+        tableId = table.id,
+        divId = table.parentNode.id;
+
+        var onclickEvent = onclickString.replace('%elementId%', detailRowId).
+        replace('%tableId%', tableId).
+        replace('%divId%', divId);
+
+        toggleRow.setAttribute('onclick', onclickEvent);
+      }
+    }
+    setToggleIds();
 
 </script>

--- a/lib/cuke_sniffer/report/js.html.erb
+++ b/lib/cuke_sniffer/report/js.html.erb
@@ -9,7 +9,7 @@
     }
 
     function expandAllShiftingRows(css_class) {
-        var elements = document.getElementsByClassName(css_class)
+        var elements = document.getElementsByClassName(css_class);
         for (var i = 0; i < elements.length; i++) {
             existing_style = elements.item(i).getAttribute('style');
             elements.item(i).setAttribute('style', existing_style.replace(/display:\s*none/, "display: block-inline"));
@@ -17,7 +17,7 @@
     }
 
     function updateAll(css_class, display_type){
-        var elements = document.getElementsByClassName(css_class)
+        var elements = document.getElementsByClassName(css_class);
         for (var i = 0; i < elements.length; i++) {
             elements.item(i).style.display = display_type;
         }
@@ -50,10 +50,11 @@
 
     function updateDisplayStatusForTR(object) {
         existing_style = object.getAttribute('style');
-        if (object.style.display == "none") {
-            object.setAttribute('style', existing_style.replace(/display:\s*none/, "display: block-inline"))
+        if (object.style.display === "none") {
+            object.style.display = ''; //have to clear out default setting of 'default: none;'
+            object.style.display = 'block-inline';
         } else {
-            object.setAttribute('style', existing_style.replace("display: block-inline", "display: none"))
+            object.style.display = 'none';
         }
     }
     function toggleText(link) {
@@ -68,7 +69,7 @@
         for (var i = 0; i < collapsibleToggleRows.length; i++) {
             toggleRow = collapsibleToggleRows[i];
 
-            var table = toggleRow.parentNode;
+            var table = toggleRow.parentNode.parentNode;
 
             var detailRowId = table.rows[ toggleRow.rowIndex + 1 ].id,
                 tableId = table.id,

--- a/lib/cuke_sniffer/report/rules.html.erb
+++ b/lib/cuke_sniffer/report/rules.html.erb
@@ -25,9 +25,9 @@
         </tr>
 
         <% if index.odd? %>
-            <tr id="rule_detail_<%= index %>" class="colored_subsection blue_row rule_detail" style="display:none;">
+            <tr id="rule_detail_<%= index %>" class="colored_subsection blue_row rule_detail" style="display: none;">
         <% else %>
-            <tr id="rule_detail_<%= index %>" class="colored_subsection white_row rule_detail" style="display:none;">
+            <tr id="rule_detail_<%= index %>" class="colored_subsection white_row rule_detail" style="display: none;">
         <% end %>
         <td style="padding-left:8px;">
           <table border="0" cellspacing="0">

--- a/lib/cuke_sniffer/report/rules.html.erb
+++ b/lib/cuke_sniffer/report/rules.html.erb
@@ -12,11 +12,11 @@
     <% index = 0 %>
     <% cuke_sniffer.rules.each do |rule| %>
         <% if !rule.enabled %>
-            <tr class="notes disabled_title_row" onclick="updateDisplayStatus(document.getElementById('rule_detail_<%=index%>'));updateDivScroll('rules', 'rules_table');">
+            <tr class="notes disabled_title_row toggleable">
         <% elsif index.odd? %>
-            <tr class="notes blue_title_row" onclick="updateDisplayStatus(document.getElementById('rule_detail_<%=index%>'));updateDivScroll('rules', 'rules_table');">
+            <tr class="notes blue_title_row toggleable">
         <% else %>
-            <tr class="notes white_title_row" onclick="updateDisplayStatus(document.getElementById('rule_detail_<%=index%>'));updateDivScroll('rules', 'rules_table');">
+            <tr class="notes white_title_row toggleable">
         <% end %>
 
             <td>

--- a/lib/cuke_sniffer/report/standard_template.html.erb
+++ b/lib/cuke_sniffer/report/standard_template.html.erb
@@ -1,6 +1,5 @@
 <%
    styles = build_page(cuke_sniffer, "css.html.erb")
-   scripts = build_page(cuke_sniffer, "js.html.erb")
    title = build_page(cuke_sniffer, "title.html.erb")
    legend = build_page(cuke_sniffer, "legend.html.erb")
    summary = build_page(cuke_sniffer, "summary.html.erb")
@@ -10,10 +9,10 @@
    features = build_page(cuke_sniffer, "features.html.erb")
    step_definitions = build_page(cuke_sniffer, "step_definitions.html.erb")
    hooks = build_page(cuke_sniffer, "hooks.html.erb")
+   scripts = build_page(cuke_sniffer, "js.html.erb")
 %>
 
 <%= styles %>
-<%= scripts %>
 <%= title %>
 <%= summary %>
 <%= improvement_list %>
@@ -22,3 +21,4 @@
 <%= features %>
 <%= step_definitions %>
 <%= hooks %>
+<%= scripts %>

--- a/lib/cuke_sniffer/report/step_definitions.html.erb
+++ b/lib/cuke_sniffer/report/step_definitions.html.erb
@@ -18,9 +18,9 @@
     <% cuke_sniffer.step_definitions.each do |step_definition| %>
         <% next if step_definition.score <= 0 %>
         <% if index.odd? %>
-            <tr class="notes blue_title_row" onclick="updateDisplayStatus(document.getElementById('step_definition_detail_<%=index%>')); updateDivScroll('step_definitions_data', 'step_definitions_table');">
+            <tr class="notes blue_title_row toggleable">
         <% else %>
-            <tr class="notes white_title_row" onclick="updateDisplayStatus(document.getElementById('step_definition_detail_<%=index%>')); updateDivScroll('step_definitions_data', 'step_definitions_table');">
+            <tr class="notes white_title_row toggleable">
         <% end %>
           <td id="step_definition_score_<%= index %>" valign="top" style="width:1%; color: red">
             <%= step_definition.score %>


### PR DESCRIPTION
Fixed `(open file)` link to not expand/collapse table row details for the Dead Steps table.

1. Created a DRY function to set the onclick events for the tables with expandable/collapsible data.
2. Moved Javascript to bottom of generated HTML document so it will work properly.
3. Created onclick function to prevent propagation up to table row element.
4. Removed unmatched `</td>` tag in hooks.html.erb and generally reformatted inline style tags for consistency.
5. Fixed expanding/collapsing of data rows in IE.
6. Tested functionality in IE 11, Firefox 31, and Chrome 39.  