### PR TITLE
Dead steps sort

### DIFF
--- a/lib/cuke_sniffer/report/css.html.erb
+++ b/lib/cuke_sniffer/report/css.html.erb
@@ -162,4 +162,9 @@
       border-top: 4px solid black;
     }
 
+    /* Move table sort arrow to the right in Firefox */
+    span:-moz-only-whitespace {
+      right: -5px;
+    }
+
 </style>

--- a/lib/cuke_sniffer/report/css.html.erb
+++ b/lib/cuke_sniffer/report/css.html.erb
@@ -130,4 +130,42 @@
 
     }
 
+    .function_button {
+      height: 25px;
+      -moz-border-radius: 10px;
+      -webkit-border-radius: 10px;
+      border-radius: 10px;
+    }
+
+    button.function_button {
+      width: 140px;
+    }
+
+    .arrow-up {
+      top: 50%;
+      margin-top: -1px;
+      margin-left: 58px;
+
+      width: 0;
+      height: 0;
+      border-left: 4px solid transparent;
+      border-right: 4px solid transparent;
+
+      border-bottom: 4px solid black;
+    }
+
+    .arrow-down {
+      top: 50%;
+      margin-top: -1px;
+      margin-bottom: 10px;
+      margin-left: 110px;
+
+      width: 0;
+      height: 0;
+      border-left: 4px solid transparent;
+      border-right: 4px solid transparent;
+
+      border-top: 4px solid black;
+    }
+
 </style>

--- a/lib/cuke_sniffer/report/css.html.erb
+++ b/lib/cuke_sniffer/report/css.html.erb
@@ -127,24 +127,19 @@
         list-style-type: none;
         display: block;
         padding-left: 1%
-
-    }
-
-    .function_button {
-      height: 25px;
-      -moz-border-radius: 10px;
-      -webkit-border-radius: 10px;
-      border-radius: 10px;
     }
 
     button.function_button {
+      position: relative;
+      top: 0;
+      left: 0;
       width: 140px;
     }
 
     .arrow-up {
-      top: 50%;
-      margin-top: -1px;
-      margin-left: 58px;
+      position: absolute;
+      right: 4px;
+      top: 40%;
 
       width: 0;
       height: 0;
@@ -155,10 +150,9 @@
     }
 
     .arrow-down {
-      top: 50%;
-      margin-top: -1px;
-      margin-bottom: 10px;
-      margin-left: 110px;
+      position: absolute;
+      right: 4px;
+      top: 40%;
 
       width: 0;
       height: 0;

--- a/lib/cuke_sniffer/report/dead_steps.html.erb
+++ b/lib/cuke_sniffer/report/dead_steps.html.erb
@@ -4,6 +4,7 @@
 <div id="dead_steps_function_bar" class="function_bar">
   <input type="button" class="function_button" value="Collapse All" onclick="collapseAll('dead_step_detail')" />
   <input type="button" class="function_button" value="Expand All" onclick="expandAllShiftingRows('dead_step_detail')" />
+  <button type="button" class="function_button" onclick="sortTable('dead_steps_table', 0)">Sort by Dead Steps <span id='dead_steps_sort_arrow'></span></button>
 </div>
 <div class="new_sub_section" id="dead_steps_data">
   <% dead_steps = cuke_sniffer.get_dead_steps %>

--- a/lib/cuke_sniffer/report/js.html.erb
+++ b/lib/cuke_sniffer/report/js.html.erb
@@ -90,41 +90,43 @@ function preventPropagation(event) {
 
   event.cancelBubble = true; // IE method
   if (event.stopPropagation) event.stopPropagation(); // Rest of the world method
-  }
+}
 
 function sortTable(tableId, sortColIndex) {
-    var table = document.getElementById(tableId);
+  var table = document.getElementById(tableId);
 
-    var groupedTable = [],
-    currentGroup = 0;
+  var groupedTable = [],
+  currentGroup = 0;
 
-    for (var i=0; i<table.rows.length; i++) {
-      if (table.rows[i].classList.contains('toggleable')) {
-        // It is a parent row
-        groupedTable.push({});
-        currentGroup = groupedTable.length - 1;
+  for (var i=0; i<table.rows.length; i++) {
+    if (table.rows[i].classList.contains('toggleable')) {
+      // It is a parent row
+      groupedTable.push({});
+      currentGroup = groupedTable.length - 1;
 
-        groupedTable[currentGroup].parent = table.rows[i];
-        groupedTable[currentGroup].children = [];
-      } else {
-        // It belongs to the previous parent
-        groupedTable[currentGroup].children.push(table.rows[i])
-      }
+      groupedTable[currentGroup].parent = table.rows[i];
+      groupedTable[currentGroup].children = [];
+    } else {
+      // It belongs to the previous parent
+      groupedTable[currentGroup].children.push(table.rows[i])
     }
-
-    groupedTable = groupedTable.sort(function(a, b) {
-      return  parseInt(b.parent.getElementsByTagName('td')[sortColIndex].innerText) -
-      parseInt(a.parent.getElementsByTagName('td')[sortColIndex].innerText);
-    });
-
-
-    table.innerHTML = "";
-    groupedTable.forEach(function(group) {
-      table.appendChild(group.parent);
-      group.children.forEach(function(child) {
-        table.appendChild(child);
-      })
-    })
   }
 
-  </script>
+  groupedTable = groupedTable.sort(function(a, b) {
+    return  parseInt(b.parent.getElementsByTagName('td')[sortColIndex].innerText) -
+    parseInt(a.parent.getElementsByTagName('td')[sortColIndex].innerText);
+  });
+
+
+  table.innerHTML = "";
+  groupedTable.forEach(function(group) {
+    table.appendChild(group.parent);
+    group.children.forEach(function(child) {
+      table.appendChild(child);
+    })
+  })
+
+  document.getElementById('dead_steps_sort_arrow').className = 'arrow-down';
+}
+
+</script>

--- a/lib/cuke_sniffer/report/js.html.erb
+++ b/lib/cuke_sniffer/report/js.html.erb
@@ -93,14 +93,17 @@
       if (event.stopPropagation) event.stopPropagation(); // Rest of the world method
     }
 
-    var sortOrder = 'descending';
     function sortTable(tableId, sortColIndex) {
       var table = document.getElementById(tableId);
 
-      var groupedTable = [],
-      currentGroup = 0;
+      var groupedTable = sortTableGroups(groupTable(table), sortColIndex);
 
-      for (var i=0; i<table.rows.length; i++) {
+      drawGroupedTable(table, groupedTable);
+    };
+
+    function groupTable(table) {
+      var groupedTable = [], currentGroup = 0;
+      for (var i = 0; i < table.rows.length; i++) {
         if (table.rows[i].classList.contains('toggleable')) {
           // It is a parent row
           groupedTable.push({});
@@ -113,23 +116,31 @@
           groupedTable[currentGroup].children.push(table.rows[i])
         }
       }
+      return groupedTable;
+    };
 
+    var sortOrder = 'descending';
+    // Ternary logic included to support multiple browsers
+    function sortTableGroups(groupedTable, sortColIndex) {
       if (sortOrder === 'descending') {
         groupedTable = groupedTable.sort(function(a, b) {
-          return  parseInt(b.parent.getElementsByTagName('td')[sortColIndex].innerText) -
-          parseInt(a.parent.getElementsByTagName('td')[sortColIndex].innerText);
+          return  parseInt(b.parent.getElementsByTagName('td')[sortColIndex][document.textContent === null ? 'textContent' : 'innerText']) -
+          parseInt(a.parent.getElementsByTagName('td')[sortColIndex][document.textContent === null ? 'textContent' : 'innerText']);
         });
         document.getElementById('dead_steps_sort_arrow').className = 'arrow-down';
         sortOrder = 'ascending';
       } else if (sortOrder === 'ascending') {
         groupedTable = groupedTable.sort(function(a, b) {
-          return  parseInt(a.parent.getElementsByTagName('td')[sortColIndex].innerText) -
-          parseInt(b.parent.getElementsByTagName('td')[sortColIndex].innerText);
+          return  parseInt(a.parent.getElementsByTagName('td')[sortColIndex][document.textContent === null ? 'textContent' : 'innerText']) -
+          parseInt(b.parent.getElementsByTagName('td')[sortColIndex][document.textContent === null ? 'textContent' : 'innerText']);
         });
         document.getElementById('dead_steps_sort_arrow').className = 'arrow-up';
         sortOrder = 'descending';
       } else {} // Nothing to do without a proper sortOrder
+      return groupedTable;
+    };
 
+    function drawGroupedTable(table, groupedTable) {
       table.innerHTML = "";
       groupedTable.forEach(function(group) {
         table.appendChild(group.parent);
@@ -137,8 +148,6 @@
           table.appendChild(child);
         });
       });
-
-
-    }
+    };
 
 </script>

--- a/lib/cuke_sniffer/report/js.html.erb
+++ b/lib/cuke_sniffer/report/js.html.erb
@@ -1,94 +1,130 @@
 <script type="text/javascript">
 
-    function collapseAll(css_class) {
-        updateAll(css_class, "none");
-    }
+function collapseAll(css_class) {
+  updateAll(css_class, "none");
+}
 
-    function expandAll(css_class) {
-        updateAll(css_class, "inline-block");
-    }
+function expandAll(css_class) {
+  updateAll(css_class, "inline-block");
+}
 
-    function expandAllShiftingRows(css_class) {
-        var elements = document.getElementsByClassName(css_class);
-        for (var i = 0; i < elements.length; i++) {
-            existing_style = elements.item(i).getAttribute('style');
-            elements.item(i).setAttribute('style', existing_style.replace(/display:\s*none/, "display: block-inline"));
-        }
-    }
+function expandAllShiftingRows(css_class) {
+  var elements = document.getElementsByClassName(css_class);
+  for (var i = 0; i < elements.length; i++) {
+    existing_style = elements.item(i).getAttribute('style');
+    elements.item(i).setAttribute('style', existing_style.replace(/display:\s*none/, "display: block-inline"));
+  }
+}
 
-    function updateAll(css_class, display_type){
-        var elements = document.getElementsByClassName(css_class);
-        for (var i = 0; i < elements.length; i++) {
-            elements.item(i).style.display = display_type;
-        }
-    }
+function updateAll(css_class, display_type){
+  var elements = document.getElementsByClassName(css_class);
+  for (var i = 0; i < elements.length; i++) {
+    elements.item(i).style.display = display_type;
+  }
+}
 
-    function toggleById(item, link) {
-        updateDisplayStatus(document.getElementById(item));
-        toggleText(link)
-    }
-    function updateDisplayStatus(object) {
-        if (object.tagName == "TR") {
-            updateDisplayStatusForTR(object);
-        } else {
-            object.style.display = (object.style.display == "block") ? 'none' : "block";
-        }
-    }
+function toggleById(item, link) {
+  updateDisplayStatus(document.getElementById(item));
+  toggleText(link)
+}
+function updateDisplayStatus(object) {
+  if (object.tagName == "TR") {
+    updateDisplayStatusForTR(object);
+  } else {
+    object.style.display = (object.style.display == "block") ? 'none' : "block";
+  }
+}
 
-    function updateDivScroll(divId, tableId) {
-        div = document.getElementById(divId);
-        table = document.getElementById(tableId);
-        if (table.offsetHeight >= 500) {
-            div.style.height = "75%";
-            div.style.overflow = "auto";
-        } else {
-            div.style.height = "";
-            div.style.overflow = "none";
-        }
+function updateDivScroll(divId, tableId) {
+  div = document.getElementById(divId);
+  table = document.getElementById(tableId);
+  if (table.offsetHeight >= 500) {
+    div.style.height = "75%";
+    div.style.overflow = "auto";
+  } else {
+    div.style.height = "";
+    div.style.overflow = "none";
+  }
 
-    }
+}
 
-    function updateDisplayStatusForTR(object) {
-        existing_style = object.getAttribute('style');
-        if (object.style.display === "none") {
-            object.style.display = ''; //have to clear out default setting of 'default: none;'
-            object.style.display = 'block-inline';
-        } else {
-            object.style.display = 'none';
-        }
-    }
-    function toggleText(link) {
-        var char_result = link.innerHTML.indexOf("+") > -1 ? "-" : "+";
-        link.innerHTML = link.innerHTML.replace(/(\+|\-)/, char_result)
-    }
+function updateDisplayStatusForTR(object) {
+  existing_style = object.getAttribute('style');
+  if (object.style.display === "none") {
+    object.style.display = ''; //have to clear out default setting of 'default: none;'
+    object.style.display = 'block-inline';
+  } else {
+    object.style.display = 'none';
+  }
+}
 
-    function setToggleIds() {
-        var collapsibleToggleRows = document.getElementsByClassName('toggleable');
-        var onclickString = "updateDisplayStatus(getElementById('%elementId%'));updateDivScroll('%divId%', '%tableId%');"
+function toggleText(link) {
+  var char_result = link.innerHTML.indexOf("+") > -1 ? "-" : "+";
+  link.innerHTML = link.innerHTML.replace(/(\+|\-)/, char_result)
+}
 
-        for (var i = 0; i < collapsibleToggleRows.length; i++) {
-            toggleRow = collapsibleToggleRows[i];
+function setToggleIds() {
+  var collapsibleToggleRows = document.getElementsByClassName('toggleable');
+  var onclickString = "updateDisplayStatus(getElementById('%elementId%'));updateDivScroll('%divId%', '%tableId%');"
 
-            var table = toggleRow.parentNode.parentNode;
+  for (var i = 0; i < collapsibleToggleRows.length; i++) {
+    toggleRow = collapsibleToggleRows[i];
 
-            var detailRowId = table.rows[ toggleRow.rowIndex + 1 ].id,
-                tableId = table.id,
-                divId = table.parentNode.id;
+    var table = toggleRow.parentNode.parentNode;
 
-            var onclickEvent = onclickString.replace('%elementId%', detailRowId).
-                               replace('%tableId%', tableId).
-                               replace('%divId%', divId);
+    var detailRowId = table.rows[ toggleRow.rowIndex + 1 ].id,
+    tableId = table.id,
+    divId = table.parentNode.id;
 
-            toggleRow.setAttribute('onclick', onclickEvent);
+    var onclickEvent = onclickString.replace('%elementId%', detailRowId).
+    replace('%tableId%', tableId).
+    replace('%divId%', divId);
+
+    toggleRow.setAttribute('onclick', onclickEvent);
+  }
+}
+setToggleIds();
+
+function preventPropagation(event) {
+  if (!event) event = window.event;
+
+  event.cancelBubble = true; // IE method
+  if (event.stopPropagation) event.stopPropagation(); // Rest of the world method
+  }
+
+  function sortDeadStepsTable(tableId) {
+    var table = document.getElementById(tableId);
+
+    var groupedTable = [],
+    currentGroup = 0;
+
+    for (var i=0; i<table.rows.length; i++) {
+      if (table.rows[i].classList.contains('toggleable')) {
+        // It is a parent row
+        groupedTable.push({});
+        currentGroup = groupedTable.length - 1;
+
+        groupedTable[currentGroup].parent = table.rows[i];
+        groupedTable[currentGroup].children = [];
+      } else {
+        // It belongs to the previous parent
+        groupedTable[currentGroup].children.push(table.rows[i])
       }
     }
-    setToggleIds();
 
-    function preventPropagation(event) {
-        if (!event) event = window.event;
+    groupedTable = groupedTable.sort(function(a, b) {
+      return  parseInt(b.parent.firstElementChild.innerText) -
+      parseInt(a.parent.firstElementChild.innerText);
+    });
 
-        event.cancelBubble = true; // IE method
-        if (event.stopPropagation) event.stopPropagation(); // Rest of the world method
-    }
 
-</script>
+    table.innerHTML = "";
+    groupedTable.forEach(function(group) {
+      table.appendChild(group.parent);
+      group.children.forEach(function(child) {
+        table.appendChild(child);
+      })
+    })
+  }
+
+  </script>

--- a/lib/cuke_sniffer/report/js.html.erb
+++ b/lib/cuke_sniffer/report/js.html.erb
@@ -92,7 +92,7 @@ function preventPropagation(event) {
   if (event.stopPropagation) event.stopPropagation(); // Rest of the world method
   }
 
-  function sortDeadStepsTable(tableId) {
+function sortTable(tableId, sortColIndex) {
     var table = document.getElementById(tableId);
 
     var groupedTable = [],
@@ -113,8 +113,8 @@ function preventPropagation(event) {
     }
 
     groupedTable = groupedTable.sort(function(a, b) {
-      return  parseInt(b.parent.firstElementChild.innerText) -
-      parseInt(a.parent.firstElementChild.innerText);
+      return  parseInt(b.parent.getElementsByTagName('td')[sortColIndex].innerText) -
+      parseInt(a.parent.getElementsByTagName('td')[sortColIndex].innerText);
     });
 
 

--- a/spec/cuke_sniffer/formatter_spec.rb
+++ b/spec/cuke_sniffer/formatter_spec.rb
@@ -7,7 +7,7 @@ describe CukeSniffer::Formatter do
   end
 
   after(:each) do
-    #delete_temp_files
+    delete_temp_files
   end
 
   describe "sorting cucumber objects by score" do

--- a/spec/cuke_sniffer/formatter_spec.rb
+++ b/spec/cuke_sniffer/formatter_spec.rb
@@ -7,7 +7,7 @@ describe CukeSniffer::Formatter do
   end
 
   after(:each) do
-    delete_temp_files
+    #delete_temp_files
   end
 
   describe "sorting cucumber objects by score" do


### PR DESCRIPTION
Added a button to the Dead Steps function bar with an onclick event to sort the tables below.

Tested functionality and appearance in Chrome 40, Firefox 35, and Safari 7.1.2.

* Sorry about the code reformatting... Atom editor seems to have a mind of its own sometimes.