### PR TITLE
Ignore .feature directories

### DIFF
--- a/lib/cuke_sniffer/cli.rb
+++ b/lib/cuke_sniffer/cli.rb
@@ -260,7 +260,7 @@ module CukeSniffer
         if File.file?(pattern_location)
           [pattern_location]
         else
-          Dir["#{pattern_location}/**/*.#{extension}"]
+          Dir["#{pattern_location}/**/*.#{extension}"].select { |f| File.file? f }
         end
       end
     end


### PR DESCRIPTION
cuke_sniffer choked for me, because coverage reporting created *.feature directories. This fixes that.