### PR TITLE
Alexives/add junit output

### DIFF
--- a/bin/cuke_sniffer
+++ b/bin/cuke_sniffer
@@ -6,7 +6,7 @@ require 'cuke_sniffer'
 help_cmd_txt = "Welcome to CukeSniffer!
 Calling CukeSniffer with no arguments will run it against the current directory.
 Other Options for Running include:
-  -o, --out <type> (name)                   : Where <type> is 'html', 'min_html' or 'xml'.
+  -o, --out <type> (name)                   : Where <type> is 'html', 'min_html', 'junit_xml' or 'xml'.
                                               Runs CukeSniffer then outputs an
                                               html/xml file in the current
                                               directory (with optional name).
@@ -50,6 +50,7 @@ def handle_output(argv)
         :html => "html",
         :min_html => "min_html",
         :xml => "xml",
+        :junit_xml => "junit_xml",
     }
     output_type_hash.each_value do |value|
       index_of_key = argv.index(value)
@@ -72,6 +73,8 @@ def call_output(file_type, file_name)
       file_name.nil? ? @cuke_sniffer.output_html : @cuke_sniffer.output_html(file_name)
     when "min_html"
       file_name.nil? ? @cuke_sniffer.output_min_html : @cuke_sniffer.output_min_html(file_name)
+    when "junit_xml"
+      file_name.nil? ? @cuke_sniffer.output_junit_xml : @cuke_sniffer.output_junit_xml(file_name)
     else
       puts "#{file_type} is not a supported version of cuke_sniffer output."
   end

--- a/examples/complex_project/junit_cuke_sniffer_results.xml
+++ b/examples/complex_project/junit_cuke_sniffer_results.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0"?>
+<testsuites tests="9" failures="73">
+  <testcase classname="features/features/scenarios/empty_feature.feature">
+    <failure message="Severity: 1 - Error: Feature has no description."/>
+    <failure message="Severity: 1 - Error: Feature with no scenarios."/>
+    <failure message="Severity: 1 - Error: Feature file has no content."/>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature">
+    <failure message="Severity: 1 - Error: Feature has numbers in the description."/>
+    <failure message="Severity: 6 - Error: Same tag appears on Feature."/>
+    <failure message="Severity: 1 - Error: Tag appears on all scenarios."/>
+    <failure message="Severity: 1 - Line: 6 - Error: Scenario steps out of Given/When/Then order."/>
+    <failure message="Severity: 1 - Line: 6 - Error: Given/When/Then used multiple times in the same Scenario."/>
+    <failure message="Severity: 2 - Line: 6 - Error: Implementation word used: text box."/>
+    <failure message="Severity: 1 - Line: 6 - Error: Implementation word used: page."/>
+    <failure message="Severity: 1 - Line: 6 - Error: Implementation word used: button."/>
+    <failure message="Severity: 1 - Line: 14 - Error: Scenario steps out of Given/When/Then order."/>
+    <failure message="Severity: 1 - Line: 14 - Error: Given/When/Then used multiple times in the same Scenario."/>
+    <failure message="Severity: 2 - Line: 14 - Error: Implementation word used: text box."/>
+    <failure message="Severity: 1 - Line: 14 - Error: Implementation word used: screen."/>
+    <failure message="Severity: 1 - Line: 14 - Error: Implementation word used: pop up."/>
+    <failure message="Severity: 1 - Line: 14 - Error: Implementation word used: button."/>
+    <failure message="Severity: 1 - Line: 24 - Error: Scenario steps out of Given/When/Then order."/>
+    <failure message="Severity: 1 - Line: 24 - Error: Given/When/Then used multiple times in the same Scenario."/>
+    <failure message="Severity: 1 - Line: 24 - Error: Implementation word used: page."/>
+    <failure message="Severity: 1 - Line: 24 - Error: Implementation word used: click."/>
+    <failure message="Severity: 1 - Line: 24 - Error: Implementation word used: button."/>
+    <failure message="Severity: 1 - Line: 35 - Error: Scenario steps out of Given/When/Then order."/>
+    <failure message="Severity: 1 - Line: 35 - Error: Given/When/Then used multiple times in the same Scenario."/>
+    <failure message="Severity: 1 - Line: 35 - Error: Implementation word used: page."/>
+    <failure message="Severity: 1 - Line: 35 - Error: Implementation word used: click."/>
+    <failure message="Severity: 1 - Line: 35 - Error: Implementation word used: button."/>
+    <failure message="Severity: 1 - Line: 44 - Error: Scenario has no description."/>
+    <failure message="Severity: 1 - Line: 44 - Error: Scenario steps out of Given/When/Then order."/>
+    <failure message="Severity: 1 - Line: 44 - Error: Scenario Outline with only one example."/>
+    <failure message="Severity: 1 - Line: 44 - Error: Given/When/Then used multiple times in the same Scenario Outline."/>
+    <failure message="Severity: 2 - Line: 44 - Error: Implementation word used: text box."/>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/KY/rate.feature">
+    <failure message="Severity: 1 - Error: Feature has numbers in the description."/>
+    <failure message="Severity: 1 - Error: There are commas in the description, creating possible multirunning scenarios or features."/>
+    <failure message="Severity: 223 - Line: 5 - Error: Commented example."/>
+    <failure message="Severity: 1 - Line: 5 - Error: Scenario Outline with too many examples."/>
+    <failure message="Severity: 1 - Line: 514 - Error: Scenario steps out of Given/When/Then order."/>
+    <failure message="Severity: 1 - Line: 518 - Error: Scenario steps out of Given/When/Then order."/>
+    <failure message="Severity: 1 - Line: 522 - Error: Scenario steps out of Given/When/Then order."/>
+    <failure message="Severity: 1 - Line: 526 - Error: Scenario steps out of Given/When/Then order."/>
+    <failure message="Severity: 1 - Line: 530 - Error: Scenario steps out of Given/When/Then order."/>
+    <failure message="Severity: 1 - Line: 534 - Error: Scenario steps out of Given/When/Then order."/>
+    <failure message="Severity: 2 - Line: 534 - Error: Implementation word used: screen."/>
+    <failure message="Severity: 1 - Line: 534 - Error: Implementation word used: click."/>
+    <failure message="Severity: 1 - Line: 534 - Error: Implementation word used: button."/>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/OH/rate.feature">
+    <failure message="Severity: 1 - Error: Feature has numbers in the description."/>
+    <failure message="Severity: 1 - Error: There are commas in the description, creating possible multirunning scenarios or features."/>
+    <failure message="Severity: 223 - Line: 5 - Error: Commented example."/>
+    <failure message="Severity: 1 - Line: 5 - Error: Scenario Outline with too many examples."/>
+    <failure message="Severity: 1 - Line: 515 - Error: Scenario steps out of Given/When/Then order."/>
+    <failure message="Severity: 1 - Line: 519 - Error: Scenario steps out of Given/When/Then order."/>
+    <failure message="Severity: 1 - Line: 523 - Error: Scenario steps out of Given/When/Then order."/>
+    <failure message="Severity: 1 - Line: 527 - Error: Scenario steps out of Given/When/Then order."/>
+    <failure message="Severity: 1 - Line: 531 - Error: Scenario steps out of Given/When/Then order."/>
+    <failure message="Severity: 1 - Line: 535 - Error: Scenario steps out of Given/When/Then order."/>
+    <failure message="Severity: 2 - Line: 535 - Error: Implementation word used: screen."/>
+    <failure message="Severity: 1 - Line: 535 - Error: Implementation word used: click."/>
+    <failure message="Severity: 1 - Line: 535 - Error: Implementation word used: button."/>
+  </testcase>
+  <testcase classname="features/features/step_definitions/my_steps.rb">
+    <failure message="Severity: 1 - Line: 1 - Error: Lazy Debugging through puts, p, or print"/>
+  </testcase>
+  <testcase classname="features/features/step_definitions/old_steps/older_steps.rb">
+    <failure message="Severity: 2 - Line: 1 - Error: Lazy Debugging through puts, p, or print"/>
+    <failure message="Severity: 1 - Line: 1 - Error: Small sleeps used. Use a wait_until like method."/>
+    <failure message="Severity: 1 - Line: 7 - Error: Lazy Debugging through puts, p, or print"/>
+    <failure message="Severity: 1 - Line: 7 - Error: Small sleeps used. Use a wait_until like method."/>
+    <failure message="Severity: 1 - Line: 7 - Error: Large sleeps used. Use a wait_until like method."/>
+  </testcase>
+  <testcase classname="features/features/step_definitions/old_steps/other_team_steps.rb">
+    <failure message="Severity: 3 - Line: 1 - Error: Commented code in Step Definition."/>
+    <failure message="Severity: 3 - Line: 7 - Error: Commented code in Step Definition."/>
+    <failure message="Severity: 3 - Line: 13 - Error: Commented code in Step Definition."/>
+    <failure message="Severity: 3 - Line: 19 - Error: Commented code in Step Definition."/>
+    <failure message="Severity: 3 - Line: 25 - Error: Commented code in Step Definition."/>
+  </testcase>
+  <testcase classname="features/features/support/env.rb">
+    <failure message="Severity: 1 - Line: 1 - Error: Hook without a begin/rescue. Reduced visibility when debugging."/>
+    <failure message="Severity: 1 - Line: 1 - Error: Hook found outside of the designated hooks file"/>
+  </testcase>
+  <testcase classname="features/features/support/hooks.rb">
+    <failure message="Severity: 1 - Line: 1 - Error: Hook without a begin/rescue. Reduced visibility when debugging."/>
+    <failure message="Severity: 1 - Line: 6 - Error: Hook without a begin/rescue. Reduced visibility when debugging."/>
+  </testcase>
+</testsuites>

--- a/examples/simple_project/junit_cuke_sniffer_results.xml
+++ b/examples/simple_project/junit_cuke_sniffer_results.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<testsuites tests="8" failures="12">
+  <testcase classname="features/scenarios/complex_calculator.feature"/>
+  <testcase classname="features/scenarios/nested_directory/nested_feature.feature">
+    <failure message="Severity: 1 - Line: 3 - Error: Scenario steps out of Given/When/Then order."/>
+  </testcase>
+  <testcase classname="features/scenarios/simple_calculator.feature"/>
+  <testcase classname="features/step_definitions/complex_calculator_steps.rb"/>
+  <testcase classname="features/step_definitions/nested_steps/nested_steps.rb">
+    <failure message="Severity: 1 - Line: 1 - Error: Lazy Debugging through puts, p, or print"/>
+  </testcase>
+  <testcase classname="features/step_definitions/simple_calculator_steps.rb">
+    <failure message="Severity: 1 - Line: 1 - Error: Nested step call."/>
+  </testcase>
+  <testcase classname="features/support/env.rb">
+    <failure message="Severity: 1 - Line: 1 - Error: Hook with no content."/>
+    <failure message="Severity: 1 - Line: 1 - Error: Hook is only comments."/>
+    <failure message="Severity: 1 - Line: 1 - Error: Hook found outside of the designated hooks file"/>
+  </testcase>
+  <testcase classname="features/support/hooks.rb">
+    <failure message="Severity: 1 - Line: 1 - Error: Hook without a begin/rescue. Reduced visibility when debugging."/>
+    <failure message="Severity: 1 - Line: 5 - Error: Hook without a begin/rescue. Reduced visibility when debugging."/>
+    <failure message="Severity: 1 - Line: 9 - Error: Hook without a begin/rescue. Reduced visibility when debugging."/>
+    <failure message="Severity: 1 - Line: 13 - Error: Hook without a begin/rescue. Reduced visibility when debugging."/>
+    <failure message="Severity: 1 - Line: 17 - Error: Hook without a begin/rescue. Reduced visibility when debugging."/>
+    <failure message="Severity: 1 - Line: 21 - Error: Hook without a begin/rescue. Reduced visibility when debugging."/>
+  </testcase>
+</testsuites>

--- a/lib/cuke_sniffer/cli.rb
+++ b/lib/cuke_sniffer/cli.rb
@@ -149,6 +149,15 @@ module CukeSniffer
       CukeSniffer::Formatter.output_xml(self, file_name)
     end
 
+    # Creates a xml file with the collected project details
+    # file_name defaults to "cuke_sniffer.xml" unless specified
+    #  cuke_sniffer.output_xml
+    # Or
+    #  cuke_sniffer.output_xml("cuke_sniffer01-01-0001.xml")
+    def output_junit_xml(file_name = DEFAULT_OUTPUT_FILE_NAME + ".xml")
+      CukeSniffer::Formatter.output_junit_xml(self, file_name)
+    end
+
     # Gathers all StepDefinitions that have no calls
     # Returns a hash that has two different types of records
     # 1: String of the file with a dead step with an array of the line and regex of each dead step

--- a/spec/cuke_sniffer/formatter_spec.rb
+++ b/spec/cuke_sniffer/formatter_spec.rb
@@ -255,4 +255,35 @@ describe CukeSniffer::Formatter do
 
   end
 
+  describe "creating_junit_xml_output" do
+    before(:each) do
+      @file_name = "my_xml.xml"
+    end
+
+    it "should generate a junit xml file with failures by file" do
+      cuke_sniffer = CukeSniffer::CLI.new()
+      CukeSniffer::Formatter.output_junit_xml(cuke_sniffer, @file_name)
+      File.exists?(@file_name).should == true
+    end
+
+    it "should generate results that look like junit xml" do
+      cuke_sniffer = CukeSniffer::CLI.new()
+      xml = CukeSniffer::Formatter.output_junit_xml(cuke_sniffer, @file_name)
+
+      expect(xml).to match(/<testsuites/)
+      expect(xml).to match(/tests="17"/)
+      expect(xml).to match(/\.feature/)
+      expect(xml).to match(/<failure message=/)
+      expect(xml).to match(/<testcase classname=/)
+      expect(xml).to match(/<\/testsuites>/)
+      expect(xml).to match(/<\/testcase>/)
+    end
+
+    it "should append .xml to the end of passed file name if it does have an extension already" do
+      cuke_sniffer = CukeSniffer::CLI.new()
+      CukeSniffer::Formatter.output_junit_xml(cuke_sniffer, "my_xml")
+      File.exists?("my_xml.xml").should be_true
+    end
+  end
+
 end


### PR DESCRIPTION
Most CI systems these days support junit output. By supporting junit xml format it's easy to integrate this static analysis in with a general continuous integration system.

~~I also updated the gem files in the gemfile.lock because the code climate plugin said that the gems had some vulnerabilities, and I figured that was something easy to fix.~~

This project looks pretty dead, so I don't have super high hopes of getting this merged, but I figured I'd try before committing to my fork and cutting my own gem.