### PR TITLE
Fixed junit output to work with jenkins

### DIFF
--- a/examples/complex_project/junit_cuke_sniffer_results.xml
+++ b/examples/complex_project/junit_cuke_sniffer_results.xml
@@ -1,94 +1,368 @@
 <?xml version="1.0"?>
 <testsuites tests="9" failures="73">
-  <testcase classname="features/features/scenarios/empty_feature.feature">
-    <failure message="Severity: 1 - Error: Feature has no description."/>
-    <failure message="Severity: 1 - Error: Feature with no scenarios."/>
-    <failure message="Severity: 1 - Error: Feature file has no content."/>
+  <testcase classname="features/features/scenarios/empty_feature.feature" name="full_file" time="0">
+    <failure type="failure" message="Feature has no description.">Severity: 1
+Location: features/features/scenarios/empty_feature.feature
+Error: Feature has no description.</failure>
   </testcase>
-  <testcase classname="features/features/scenarios/login.feature">
-    <failure message="Severity: 1 - Error: Feature has numbers in the description."/>
-    <failure message="Severity: 6 - Error: Same tag appears on Feature."/>
-    <failure message="Severity: 1 - Error: Tag appears on all scenarios."/>
-    <failure message="Severity: 1 - Line: 6 - Error: Scenario steps out of Given/When/Then order."/>
-    <failure message="Severity: 1 - Line: 6 - Error: Given/When/Then used multiple times in the same Scenario."/>
-    <failure message="Severity: 2 - Line: 6 - Error: Implementation word used: text box."/>
-    <failure message="Severity: 1 - Line: 6 - Error: Implementation word used: page."/>
-    <failure message="Severity: 1 - Line: 6 - Error: Implementation word used: button."/>
-    <failure message="Severity: 1 - Line: 14 - Error: Scenario steps out of Given/When/Then order."/>
-    <failure message="Severity: 1 - Line: 14 - Error: Given/When/Then used multiple times in the same Scenario."/>
-    <failure message="Severity: 2 - Line: 14 - Error: Implementation word used: text box."/>
-    <failure message="Severity: 1 - Line: 14 - Error: Implementation word used: screen."/>
-    <failure message="Severity: 1 - Line: 14 - Error: Implementation word used: pop up."/>
-    <failure message="Severity: 1 - Line: 14 - Error: Implementation word used: button."/>
-    <failure message="Severity: 1 - Line: 24 - Error: Scenario steps out of Given/When/Then order."/>
-    <failure message="Severity: 1 - Line: 24 - Error: Given/When/Then used multiple times in the same Scenario."/>
-    <failure message="Severity: 1 - Line: 24 - Error: Implementation word used: page."/>
-    <failure message="Severity: 1 - Line: 24 - Error: Implementation word used: click."/>
-    <failure message="Severity: 1 - Line: 24 - Error: Implementation word used: button."/>
-    <failure message="Severity: 1 - Line: 35 - Error: Scenario steps out of Given/When/Then order."/>
-    <failure message="Severity: 1 - Line: 35 - Error: Given/When/Then used multiple times in the same Scenario."/>
-    <failure message="Severity: 1 - Line: 35 - Error: Implementation word used: page."/>
-    <failure message="Severity: 1 - Line: 35 - Error: Implementation word used: click."/>
-    <failure message="Severity: 1 - Line: 35 - Error: Implementation word used: button."/>
-    <failure message="Severity: 1 - Line: 44 - Error: Scenario has no description."/>
-    <failure message="Severity: 1 - Line: 44 - Error: Scenario steps out of Given/When/Then order."/>
-    <failure message="Severity: 1 - Line: 44 - Error: Scenario Outline with only one example."/>
-    <failure message="Severity: 1 - Line: 44 - Error: Given/When/Then used multiple times in the same Scenario Outline."/>
-    <failure message="Severity: 2 - Line: 44 - Error: Implementation word used: text box."/>
+  <testcase classname="features/features/scenarios/empty_feature.feature" name="full_file" time="0">
+    <failure type="failure" message="Feature with no scenarios.">Severity: 1
+Location: features/features/scenarios/empty_feature.feature
+Error: Feature with no scenarios.</failure>
   </testcase>
-  <testcase classname="features/features/scenarios/RATE/KY/rate.feature">
-    <failure message="Severity: 1 - Error: Feature has numbers in the description."/>
-    <failure message="Severity: 1 - Error: There are commas in the description, creating possible multirunning scenarios or features."/>
-    <failure message="Severity: 223 - Line: 5 - Error: Commented example."/>
-    <failure message="Severity: 1 - Line: 5 - Error: Scenario Outline with too many examples."/>
-    <failure message="Severity: 1 - Line: 514 - Error: Scenario steps out of Given/When/Then order."/>
-    <failure message="Severity: 1 - Line: 518 - Error: Scenario steps out of Given/When/Then order."/>
-    <failure message="Severity: 1 - Line: 522 - Error: Scenario steps out of Given/When/Then order."/>
-    <failure message="Severity: 1 - Line: 526 - Error: Scenario steps out of Given/When/Then order."/>
-    <failure message="Severity: 1 - Line: 530 - Error: Scenario steps out of Given/When/Then order."/>
-    <failure message="Severity: 1 - Line: 534 - Error: Scenario steps out of Given/When/Then order."/>
-    <failure message="Severity: 2 - Line: 534 - Error: Implementation word used: screen."/>
-    <failure message="Severity: 1 - Line: 534 - Error: Implementation word used: click."/>
-    <failure message="Severity: 1 - Line: 534 - Error: Implementation word used: button."/>
+  <testcase classname="features/features/scenarios/empty_feature.feature" name="full_file" time="0">
+    <failure type="failure" message="Feature file has no content.">Severity: 1
+Location: features/features/scenarios/empty_feature.feature
+Error: Feature file has no content.</failure>
   </testcase>
-  <testcase classname="features/features/scenarios/RATE/OH/rate.feature">
-    <failure message="Severity: 1 - Error: Feature has numbers in the description."/>
-    <failure message="Severity: 1 - Error: There are commas in the description, creating possible multirunning scenarios or features."/>
-    <failure message="Severity: 223 - Line: 5 - Error: Commented example."/>
-    <failure message="Severity: 1 - Line: 5 - Error: Scenario Outline with too many examples."/>
-    <failure message="Severity: 1 - Line: 515 - Error: Scenario steps out of Given/When/Then order."/>
-    <failure message="Severity: 1 - Line: 519 - Error: Scenario steps out of Given/When/Then order."/>
-    <failure message="Severity: 1 - Line: 523 - Error: Scenario steps out of Given/When/Then order."/>
-    <failure message="Severity: 1 - Line: 527 - Error: Scenario steps out of Given/When/Then order."/>
-    <failure message="Severity: 1 - Line: 531 - Error: Scenario steps out of Given/When/Then order."/>
-    <failure message="Severity: 1 - Line: 535 - Error: Scenario steps out of Given/When/Then order."/>
-    <failure message="Severity: 2 - Line: 535 - Error: Implementation word used: screen."/>
-    <failure message="Severity: 1 - Line: 535 - Error: Implementation word used: click."/>
-    <failure message="Severity: 1 - Line: 535 - Error: Implementation word used: button."/>
+  <testcase classname="features/features/scenarios/login.feature" name="full_file" time="0">
+    <failure type="failure" message="Feature has numbers in the description.">Severity: 1
+Location: features/features/scenarios/login.feature
+Error: Feature has numbers in the description.</failure>
   </testcase>
-  <testcase classname="features/features/step_definitions/my_steps.rb">
-    <failure message="Severity: 1 - Line: 1 - Error: Lazy Debugging through puts, p, or print"/>
+  <testcase classname="features/features/scenarios/login.feature" name="full_file" time="0">
+    <failure type="failure" message="Same tag appears on Feature.">Severity: 6
+Location: features/features/scenarios/login.feature
+Error: Same tag appears on Feature.</failure>
   </testcase>
-  <testcase classname="features/features/step_definitions/old_steps/older_steps.rb">
-    <failure message="Severity: 2 - Line: 1 - Error: Lazy Debugging through puts, p, or print"/>
-    <failure message="Severity: 1 - Line: 1 - Error: Small sleeps used. Use a wait_until like method."/>
-    <failure message="Severity: 1 - Line: 7 - Error: Lazy Debugging through puts, p, or print"/>
-    <failure message="Severity: 1 - Line: 7 - Error: Small sleeps used. Use a wait_until like method."/>
-    <failure message="Severity: 1 - Line: 7 - Error: Large sleeps used. Use a wait_until like method."/>
+  <testcase classname="features/features/scenarios/login.feature" name="full_file" time="0">
+    <failure type="failure" message="Tag appears on all scenarios.">Severity: 1
+Location: features/features/scenarios/login.feature
+Error: Tag appears on all scenarios.</failure>
   </testcase>
-  <testcase classname="features/features/step_definitions/old_steps/other_team_steps.rb">
-    <failure message="Severity: 3 - Line: 1 - Error: Commented code in Step Definition."/>
-    <failure message="Severity: 3 - Line: 7 - Error: Commented code in Step Definition."/>
-    <failure message="Severity: 3 - Line: 13 - Error: Commented code in Step Definition."/>
-    <failure message="Severity: 3 - Line: 19 - Error: Commented code in Step Definition."/>
-    <failure message="Severity: 3 - Line: 25 - Error: Commented code in Step Definition."/>
+  <testcase classname="features/features/scenarios/login.feature" name="6" time="0">
+    <failure type="failure" message="Scenario steps out of Given/When/Then order.">Severity: 1
+Location: features/features/scenarios/login.feature:6
+Error: Scenario steps out of Given/When/Then order.</failure>
   </testcase>
-  <testcase classname="features/features/support/env.rb">
-    <failure message="Severity: 1 - Line: 1 - Error: Hook without a begin/rescue. Reduced visibility when debugging."/>
-    <failure message="Severity: 1 - Line: 1 - Error: Hook found outside of the designated hooks file"/>
+  <testcase classname="features/features/scenarios/login.feature" name="6" time="0">
+    <failure type="failure" message="Given/When/Then used multiple times in the same Scenario.">Severity: 1
+Location: features/features/scenarios/login.feature:6
+Error: Given/When/Then used multiple times in the same Scenario.</failure>
   </testcase>
-  <testcase classname="features/features/support/hooks.rb">
-    <failure message="Severity: 1 - Line: 1 - Error: Hook without a begin/rescue. Reduced visibility when debugging."/>
-    <failure message="Severity: 1 - Line: 6 - Error: Hook without a begin/rescue. Reduced visibility when debugging."/>
+  <testcase classname="features/features/scenarios/login.feature" name="6" time="0">
+    <failure type="failure" message="Implementation word used: text box.">Severity: 2
+Location: features/features/scenarios/login.feature:6
+Error: Implementation word used: text box.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="6" time="0">
+    <failure type="failure" message="Implementation word used: page.">Severity: 1
+Location: features/features/scenarios/login.feature:6
+Error: Implementation word used: page.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="6" time="0">
+    <failure type="failure" message="Implementation word used: button.">Severity: 1
+Location: features/features/scenarios/login.feature:6
+Error: Implementation word used: button.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="14" time="0">
+    <failure type="failure" message="Scenario steps out of Given/When/Then order.">Severity: 1
+Location: features/features/scenarios/login.feature:14
+Error: Scenario steps out of Given/When/Then order.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="14" time="0">
+    <failure type="failure" message="Given/When/Then used multiple times in the same Scenario.">Severity: 1
+Location: features/features/scenarios/login.feature:14
+Error: Given/When/Then used multiple times in the same Scenario.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="14" time="0">
+    <failure type="failure" message="Implementation word used: text box.">Severity: 2
+Location: features/features/scenarios/login.feature:14
+Error: Implementation word used: text box.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="14" time="0">
+    <failure type="failure" message="Implementation word used: screen.">Severity: 1
+Location: features/features/scenarios/login.feature:14
+Error: Implementation word used: screen.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="14" time="0">
+    <failure type="failure" message="Implementation word used: pop up.">Severity: 1
+Location: features/features/scenarios/login.feature:14
+Error: Implementation word used: pop up.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="14" time="0">
+    <failure type="failure" message="Implementation word used: button.">Severity: 1
+Location: features/features/scenarios/login.feature:14
+Error: Implementation word used: button.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="24" time="0">
+    <failure type="failure" message="Scenario steps out of Given/When/Then order.">Severity: 1
+Location: features/features/scenarios/login.feature:24
+Error: Scenario steps out of Given/When/Then order.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="24" time="0">
+    <failure type="failure" message="Given/When/Then used multiple times in the same Scenario.">Severity: 1
+Location: features/features/scenarios/login.feature:24
+Error: Given/When/Then used multiple times in the same Scenario.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="24" time="0">
+    <failure type="failure" message="Implementation word used: page.">Severity: 1
+Location: features/features/scenarios/login.feature:24
+Error: Implementation word used: page.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="24" time="0">
+    <failure type="failure" message="Implementation word used: click.">Severity: 1
+Location: features/features/scenarios/login.feature:24
+Error: Implementation word used: click.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="24" time="0">
+    <failure type="failure" message="Implementation word used: button.">Severity: 1
+Location: features/features/scenarios/login.feature:24
+Error: Implementation word used: button.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="35" time="0">
+    <failure type="failure" message="Scenario steps out of Given/When/Then order.">Severity: 1
+Location: features/features/scenarios/login.feature:35
+Error: Scenario steps out of Given/When/Then order.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="35" time="0">
+    <failure type="failure" message="Given/When/Then used multiple times in the same Scenario.">Severity: 1
+Location: features/features/scenarios/login.feature:35
+Error: Given/When/Then used multiple times in the same Scenario.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="35" time="0">
+    <failure type="failure" message="Implementation word used: page.">Severity: 1
+Location: features/features/scenarios/login.feature:35
+Error: Implementation word used: page.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="35" time="0">
+    <failure type="failure" message="Implementation word used: click.">Severity: 1
+Location: features/features/scenarios/login.feature:35
+Error: Implementation word used: click.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="35" time="0">
+    <failure type="failure" message="Implementation word used: button.">Severity: 1
+Location: features/features/scenarios/login.feature:35
+Error: Implementation word used: button.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="44" time="0">
+    <failure type="failure" message="Scenario has no description.">Severity: 1
+Location: features/features/scenarios/login.feature:44
+Error: Scenario has no description.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="44" time="0">
+    <failure type="failure" message="Scenario steps out of Given/When/Then order.">Severity: 1
+Location: features/features/scenarios/login.feature:44
+Error: Scenario steps out of Given/When/Then order.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="44" time="0">
+    <failure type="failure" message="Scenario Outline with only one example.">Severity: 1
+Location: features/features/scenarios/login.feature:44
+Error: Scenario Outline with only one example.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="44" time="0">
+    <failure type="failure" message="Given/When/Then used multiple times in the same Scenario Outline.">Severity: 1
+Location: features/features/scenarios/login.feature:44
+Error: Given/When/Then used multiple times in the same Scenario Outline.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/login.feature" name="44" time="0">
+    <failure type="failure" message="Implementation word used: text box.">Severity: 2
+Location: features/features/scenarios/login.feature:44
+Error: Implementation word used: text box.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/KY/rate.feature" name="full_file" time="0">
+    <failure type="failure" message="Feature has numbers in the description.">Severity: 1
+Location: features/features/scenarios/RATE/KY/rate.feature
+Error: Feature has numbers in the description.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/KY/rate.feature" name="full_file" time="0">
+    <failure type="failure" message="There are commas in the description, creating possible multirunning scenarios or features.">Severity: 1
+Location: features/features/scenarios/RATE/KY/rate.feature
+Error: There are commas in the description, creating possible multirunning scenarios or features.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/KY/rate.feature" name="5" time="0">
+    <failure type="failure" message="Commented example.">Severity: 223
+Location: features/features/scenarios/RATE/KY/rate.feature:5
+Error: Commented example.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/KY/rate.feature" name="5" time="0">
+    <failure type="failure" message="Scenario Outline with too many examples.">Severity: 1
+Location: features/features/scenarios/RATE/KY/rate.feature:5
+Error: Scenario Outline with too many examples.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/KY/rate.feature" name="514" time="0">
+    <failure type="failure" message="Scenario steps out of Given/When/Then order.">Severity: 1
+Location: features/features/scenarios/RATE/KY/rate.feature:514
+Error: Scenario steps out of Given/When/Then order.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/KY/rate.feature" name="518" time="0">
+    <failure type="failure" message="Scenario steps out of Given/When/Then order.">Severity: 1
+Location: features/features/scenarios/RATE/KY/rate.feature:518
+Error: Scenario steps out of Given/When/Then order.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/KY/rate.feature" name="522" time="0">
+    <failure type="failure" message="Scenario steps out of Given/When/Then order.">Severity: 1
+Location: features/features/scenarios/RATE/KY/rate.feature:522
+Error: Scenario steps out of Given/When/Then order.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/KY/rate.feature" name="526" time="0">
+    <failure type="failure" message="Scenario steps out of Given/When/Then order.">Severity: 1
+Location: features/features/scenarios/RATE/KY/rate.feature:526
+Error: Scenario steps out of Given/When/Then order.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/KY/rate.feature" name="530" time="0">
+    <failure type="failure" message="Scenario steps out of Given/When/Then order.">Severity: 1
+Location: features/features/scenarios/RATE/KY/rate.feature:530
+Error: Scenario steps out of Given/When/Then order.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/KY/rate.feature" name="534" time="0">
+    <failure type="failure" message="Scenario steps out of Given/When/Then order.">Severity: 1
+Location: features/features/scenarios/RATE/KY/rate.feature:534
+Error: Scenario steps out of Given/When/Then order.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/KY/rate.feature" name="534" time="0">
+    <failure type="failure" message="Implementation word used: screen.">Severity: 2
+Location: features/features/scenarios/RATE/KY/rate.feature:534
+Error: Implementation word used: screen.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/KY/rate.feature" name="534" time="0">
+    <failure type="failure" message="Implementation word used: click.">Severity: 1
+Location: features/features/scenarios/RATE/KY/rate.feature:534
+Error: Implementation word used: click.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/KY/rate.feature" name="534" time="0">
+    <failure type="failure" message="Implementation word used: button.">Severity: 1
+Location: features/features/scenarios/RATE/KY/rate.feature:534
+Error: Implementation word used: button.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/OH/rate.feature" name="full_file" time="0">
+    <failure type="failure" message="Feature has numbers in the description.">Severity: 1
+Location: features/features/scenarios/RATE/OH/rate.feature
+Error: Feature has numbers in the description.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/OH/rate.feature" name="full_file" time="0">
+    <failure type="failure" message="There are commas in the description, creating possible multirunning scenarios or features.">Severity: 1
+Location: features/features/scenarios/RATE/OH/rate.feature
+Error: There are commas in the description, creating possible multirunning scenarios or features.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/OH/rate.feature" name="5" time="0">
+    <failure type="failure" message="Commented example.">Severity: 223
+Location: features/features/scenarios/RATE/OH/rate.feature:5
+Error: Commented example.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/OH/rate.feature" name="5" time="0">
+    <failure type="failure" message="Scenario Outline with too many examples.">Severity: 1
+Location: features/features/scenarios/RATE/OH/rate.feature:5
+Error: Scenario Outline with too many examples.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/OH/rate.feature" name="515" time="0">
+    <failure type="failure" message="Scenario steps out of Given/When/Then order.">Severity: 1
+Location: features/features/scenarios/RATE/OH/rate.feature:515
+Error: Scenario steps out of Given/When/Then order.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/OH/rate.feature" name="519" time="0">
+    <failure type="failure" message="Scenario steps out of Given/When/Then order.">Severity: 1
+Location: features/features/scenarios/RATE/OH/rate.feature:519
+Error: Scenario steps out of Given/When/Then order.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/OH/rate.feature" name="523" time="0">
+    <failure type="failure" message="Scenario steps out of Given/When/Then order.">Severity: 1
+Location: features/features/scenarios/RATE/OH/rate.feature:523
+Error: Scenario steps out of Given/When/Then order.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/OH/rate.feature" name="527" time="0">
+    <failure type="failure" message="Scenario steps out of Given/When/Then order.">Severity: 1
+Location: features/features/scenarios/RATE/OH/rate.feature:527
+Error: Scenario steps out of Given/When/Then order.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/OH/rate.feature" name="531" time="0">
+    <failure type="failure" message="Scenario steps out of Given/When/Then order.">Severity: 1
+Location: features/features/scenarios/RATE/OH/rate.feature:531
+Error: Scenario steps out of Given/When/Then order.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/OH/rate.feature" name="535" time="0">
+    <failure type="failure" message="Scenario steps out of Given/When/Then order.">Severity: 1
+Location: features/features/scenarios/RATE/OH/rate.feature:535
+Error: Scenario steps out of Given/When/Then order.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/OH/rate.feature" name="535" time="0">
+    <failure type="failure" message="Implementation word used: screen.">Severity: 2
+Location: features/features/scenarios/RATE/OH/rate.feature:535
+Error: Implementation word used: screen.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/OH/rate.feature" name="535" time="0">
+    <failure type="failure" message="Implementation word used: click.">Severity: 1
+Location: features/features/scenarios/RATE/OH/rate.feature:535
+Error: Implementation word used: click.</failure>
+  </testcase>
+  <testcase classname="features/features/scenarios/RATE/OH/rate.feature" name="535" time="0">
+    <failure type="failure" message="Implementation word used: button.">Severity: 1
+Location: features/features/scenarios/RATE/OH/rate.feature:535
+Error: Implementation word used: button.</failure>
+  </testcase>
+  <testcase classname="features/features/step_definitions/my_steps.rb" name="1" time="0">
+    <failure type="failure" message="Lazy Debugging through puts, p, or print">Severity: 1
+Location: features/features/step_definitions/my_steps.rb:1
+Error: Lazy Debugging through puts, p, or print</failure>
+  </testcase>
+  <testcase classname="features/features/step_definitions/old_steps/older_steps.rb" name="1" time="0">
+    <failure type="failure" message="Lazy Debugging through puts, p, or print">Severity: 2
+Location: features/features/step_definitions/old_steps/older_steps.rb:1
+Error: Lazy Debugging through puts, p, or print</failure>
+  </testcase>
+  <testcase classname="features/features/step_definitions/old_steps/older_steps.rb" name="1" time="0">
+    <failure type="failure" message="Small sleeps used. Use a wait_until like method.">Severity: 1
+Location: features/features/step_definitions/old_steps/older_steps.rb:1
+Error: Small sleeps used. Use a wait_until like method.</failure>
+  </testcase>
+  <testcase classname="features/features/step_definitions/old_steps/older_steps.rb" name="7" time="0">
+    <failure type="failure" message="Lazy Debugging through puts, p, or print">Severity: 1
+Location: features/features/step_definitions/old_steps/older_steps.rb:7
+Error: Lazy Debugging through puts, p, or print</failure>
+  </testcase>
+  <testcase classname="features/features/step_definitions/old_steps/older_steps.rb" name="7" time="0">
+    <failure type="failure" message="Small sleeps used. Use a wait_until like method.">Severity: 1
+Location: features/features/step_definitions/old_steps/older_steps.rb:7
+Error: Small sleeps used. Use a wait_until like method.</failure>
+  </testcase>
+  <testcase classname="features/features/step_definitions/old_steps/older_steps.rb" name="7" time="0">
+    <failure type="failure" message="Large sleeps used. Use a wait_until like method.">Severity: 1
+Location: features/features/step_definitions/old_steps/older_steps.rb:7
+Error: Large sleeps used. Use a wait_until like method.</failure>
+  </testcase>
+  <testcase classname="features/features/step_definitions/old_steps/other_team_steps.rb" name="1" time="0">
+    <failure type="failure" message="Commented code in Step Definition.">Severity: 3
+Location: features/features/step_definitions/old_steps/other_team_steps.rb:1
+Error: Commented code in Step Definition.</failure>
+  </testcase>
+  <testcase classname="features/features/step_definitions/old_steps/other_team_steps.rb" name="7" time="0">
+    <failure type="failure" message="Commented code in Step Definition.">Severity: 3
+Location: features/features/step_definitions/old_steps/other_team_steps.rb:7
+Error: Commented code in Step Definition.</failure>
+  </testcase>
+  <testcase classname="features/features/step_definitions/old_steps/other_team_steps.rb" name="13" time="0">
+    <failure type="failure" message="Commented code in Step Definition.">Severity: 3
+Location: features/features/step_definitions/old_steps/other_team_steps.rb:13
+Error: Commented code in Step Definition.</failure>
+  </testcase>
+  <testcase classname="features/features/step_definitions/old_steps/other_team_steps.rb" name="19" time="0">
+    <failure type="failure" message="Commented code in Step Definition.">Severity: 3
+Location: features/features/step_definitions/old_steps/other_team_steps.rb:19
+Error: Commented code in Step Definition.</failure>
+  </testcase>
+  <testcase classname="features/features/step_definitions/old_steps/other_team_steps.rb" name="25" time="0">
+    <failure type="failure" message="Commented code in Step Definition.">Severity: 3
+Location: features/features/step_definitions/old_steps/other_team_steps.rb:25
+Error: Commented code in Step Definition.</failure>
+  </testcase>
+  <testcase classname="features/features/support/env.rb" name="1" time="0">
+    <failure type="failure" message="Hook without a begin/rescue. Reduced visibility when debugging.">Severity: 1
+Location: features/features/support/env.rb:1
+Error: Hook without a begin/rescue. Reduced visibility when debugging.</failure>
+  </testcase>
+  <testcase classname="features/features/support/env.rb" name="1" time="0">
+    <failure type="failure" message="Hook found outside of the designated hooks file">Severity: 1
+Location: features/features/support/env.rb:1
+Error: Hook found outside of the designated hooks file</failure>
+  </testcase>
+  <testcase classname="features/features/support/hooks.rb" name="1" time="0">
+    <failure type="failure" message="Hook without a begin/rescue. Reduced visibility when debugging.">Severity: 1
+Location: features/features/support/hooks.rb:1
+Error: Hook without a begin/rescue. Reduced visibility when debugging.</failure>
+  </testcase>
+  <testcase classname="features/features/support/hooks.rb" name="6" time="0">
+    <failure type="failure" message="Hook without a begin/rescue. Reduced visibility when debugging.">Severity: 1
+Location: features/features/support/hooks.rb:6
+Error: Hook without a begin/rescue. Reduced visibility when debugging.</failure>
   </testcase>
 </testsuites>

--- a/examples/simple_project/junit_cuke_sniffer_results.xml
+++ b/examples/simple_project/junit_cuke_sniffer_results.xml
@@ -1,28 +1,63 @@
 <?xml version="1.0"?>
 <testsuites tests="8" failures="12">
-  <testcase classname="features/scenarios/complex_calculator.feature"/>
-  <testcase classname="features/scenarios/nested_directory/nested_feature.feature">
-    <failure message="Severity: 1 - Line: 3 - Error: Scenario steps out of Given/When/Then order."/>
+  <testcase classname="features/scenarios/nested_directory/nested_feature.feature" name="3" time="0">
+    <failure type="failure" message="Scenario steps out of Given/When/Then order.">Severity: 1
+Location: features/scenarios/nested_directory/nested_feature.feature:3
+Error: Scenario steps out of Given/When/Then order.</failure>
   </testcase>
-  <testcase classname="features/scenarios/simple_calculator.feature"/>
-  <testcase classname="features/step_definitions/complex_calculator_steps.rb"/>
-  <testcase classname="features/step_definitions/nested_steps/nested_steps.rb">
-    <failure message="Severity: 1 - Line: 1 - Error: Lazy Debugging through puts, p, or print"/>
+  <testcase classname="features/step_definitions/nested_steps/nested_steps.rb" name="1" time="0">
+    <failure type="failure" message="Lazy Debugging through puts, p, or print">Severity: 1
+Location: features/step_definitions/nested_steps/nested_steps.rb:1
+Error: Lazy Debugging through puts, p, or print</failure>
   </testcase>
-  <testcase classname="features/step_definitions/simple_calculator_steps.rb">
-    <failure message="Severity: 1 - Line: 1 - Error: Nested step call."/>
+  <testcase classname="features/step_definitions/simple_calculator_steps.rb" name="1" time="0">
+    <failure type="failure" message="Nested step call.">Severity: 1
+Location: features/step_definitions/simple_calculator_steps.rb:1
+Error: Nested step call.</failure>
   </testcase>
-  <testcase classname="features/support/env.rb">
-    <failure message="Severity: 1 - Line: 1 - Error: Hook with no content."/>
-    <failure message="Severity: 1 - Line: 1 - Error: Hook is only comments."/>
-    <failure message="Severity: 1 - Line: 1 - Error: Hook found outside of the designated hooks file"/>
+  <testcase classname="features/support/env.rb" name="1" time="0">
+    <failure type="failure" message="Hook with no content.">Severity: 1
+Location: features/support/env.rb:1
+Error: Hook with no content.</failure>
   </testcase>
-  <testcase classname="features/support/hooks.rb">
-    <failure message="Severity: 1 - Line: 1 - Error: Hook without a begin/rescue. Reduced visibility when debugging."/>
-    <failure message="Severity: 1 - Line: 5 - Error: Hook without a begin/rescue. Reduced visibility when debugging."/>
-    <failure message="Severity: 1 - Line: 9 - Error: Hook without a begin/rescue. Reduced visibility when debugging."/>
-    <failure message="Severity: 1 - Line: 13 - Error: Hook without a begin/rescue. Reduced visibility when debugging."/>
-    <failure message="Severity: 1 - Line: 17 - Error: Hook without a begin/rescue. Reduced visibility when debugging."/>
-    <failure message="Severity: 1 - Line: 21 - Error: Hook without a begin/rescue. Reduced visibility when debugging."/>
+  <testcase classname="features/support/env.rb" name="1" time="0">
+    <failure type="failure" message="Hook is only comments.">Severity: 1
+Location: features/support/env.rb:1
+Error: Hook is only comments.</failure>
+  </testcase>
+  <testcase classname="features/support/env.rb" name="1" time="0">
+    <failure type="failure" message="Hook found outside of the designated hooks file">Severity: 1
+Location: features/support/env.rb:1
+Error: Hook found outside of the designated hooks file</failure>
+  </testcase>
+  <testcase classname="features/support/hooks.rb" name="1" time="0">
+    <failure type="failure" message="Hook without a begin/rescue. Reduced visibility when debugging.">Severity: 1
+Location: features/support/hooks.rb:1
+Error: Hook without a begin/rescue. Reduced visibility when debugging.</failure>
+  </testcase>
+  <testcase classname="features/support/hooks.rb" name="5" time="0">
+    <failure type="failure" message="Hook without a begin/rescue. Reduced visibility when debugging.">Severity: 1
+Location: features/support/hooks.rb:5
+Error: Hook without a begin/rescue. Reduced visibility when debugging.</failure>
+  </testcase>
+  <testcase classname="features/support/hooks.rb" name="9" time="0">
+    <failure type="failure" message="Hook without a begin/rescue. Reduced visibility when debugging.">Severity: 1
+Location: features/support/hooks.rb:9
+Error: Hook without a begin/rescue. Reduced visibility when debugging.</failure>
+  </testcase>
+  <testcase classname="features/support/hooks.rb" name="13" time="0">
+    <failure type="failure" message="Hook without a begin/rescue. Reduced visibility when debugging.">Severity: 1
+Location: features/support/hooks.rb:13
+Error: Hook without a begin/rescue. Reduced visibility when debugging.</failure>
+  </testcase>
+  <testcase classname="features/support/hooks.rb" name="17" time="0">
+    <failure type="failure" message="Hook without a begin/rescue. Reduced visibility when debugging.">Severity: 1
+Location: features/support/hooks.rb:17
+Error: Hook without a begin/rescue. Reduced visibility when debugging.</failure>
+  </testcase>
+  <testcase classname="features/support/hooks.rb" name="21" time="0">
+    <failure type="failure" message="Hook without a begin/rescue. Reduced visibility when debugging.">Severity: 1
+Location: features/support/hooks.rb:21
+Error: Hook without a begin/rescue. Reduced visibility when debugging.</failure>
   </testcase>
 </testsuites>

--- a/lib/cuke_sniffer/formatter.rb
+++ b/lib/cuke_sniffer/formatter.rb
@@ -118,17 +118,20 @@ module CukeSniffer
       current.each do |test|
         location = test.location.gsub("#{Dir.pwd}/", '')
         location_no_line = location.gsub(/:[0-9]*/,'')
-        line_num = location.gsub!(/.*:(.*)/, "- Line: \\1 ")
-        errors = test.rules_hash.keys.map {|f| "Severity: #{test.rules_hash[f]} #{line_num}- Error: #{f}"}
+        line_num = location.gsub!(/.*:(.*)/, "\\1")
+        errors = test.rules_hash.keys.map {|f| {:line => line_num,
+                                                :severity => test.rules_hash,
+                                                :error => f,
+                                                :formatted => "Severity: #{test.rules_hash[f]}\nLocation: #{location}\nError: #{f}"}}
         results[location_no_line] = results[location_no_line].nil? ? errors : results[location_no_line].concat(errors)
         failures += test.rules_hash.size
       end
       builder = Nokogiri::XML::Builder.new do |xml|
         xml.testsuites(:tests => results.size, :failures => failures) do
           results.each do |location, failures|
-            xml.testcase(:classname => location) do
-              failures.each do |failure|
-                xml.failure(:message => failure)
+            failures.each do |failure|
+              xml.testcase(:classname => location, :name => failure[:line].nil? ? "full_file" : failure[:line], :time => 0) do
+                xml.failure(failure[:formatted], :type => 'failure', :message => failure[:error])
               end
             end
           end

--- a/lib/cuke_sniffer/formatter.rb
+++ b/lib/cuke_sniffer/formatter.rb
@@ -118,7 +118,7 @@ module CukeSniffer
       current.each do |test|
         location = test.location.gsub("#{Dir.pwd}/", '')
         location_no_line = location.gsub(/:[0-9]*/,'')
-        line_num = location.gsub!(/.*:(.*)/, "\\1")
+        line_num = location.include?(":") ? location.gsub(/.*:(.*)/, "\\1") : "full_file"
         errors = test.rules_hash.keys.map {|f| {:line => line_num,
                                                 :severity => test.rules_hash,
                                                 :error => f,
@@ -130,7 +130,7 @@ module CukeSniffer
         xml.testsuites(:tests => results.size, :failures => failures) do
           results.each do |location, failures|
             failures.each do |failure|
-              xml.testcase(:classname => location, :name => failure[:line].nil? ? "full_file" : failure[:line], :time => 0) do
+              xml.testcase(:classname => location, :name => failure[:line], :time => 0) do
                 xml.failure(failure[:formatted], :type => 'failure', :message => failure[:error])
               end
             end

--- a/spec/cuke_sniffer/formatter_spec.rb
+++ b/spec/cuke_sniffer/formatter_spec.rb
@@ -273,7 +273,7 @@ describe CukeSniffer::Formatter do
       expect(xml).to match(/<testsuites/)
       expect(xml).to match(/tests="17"/)
       expect(xml).to match(/\.feature/)
-      expect(xml).to match(/<failure message=/)
+      expect(xml).to match(/<failure type="failure" message=/)
       expect(xml).to match(/<testcase classname=/)
       expect(xml).to match(/<\/testsuites>/)
       expect(xml).to match(/<\/testcase>/)


### PR DESCRIPTION
Turns out there were a bunch of bugs in this. Although it was valid junit xml, jenkins has a lot of fields it actually requires and sorta blows up if you don't have 'em. So, here's the fixed version. I've also attached a screenshot of the result from the "complex" example project.

![jenkins complex example](https://cloud.githubusercontent.com/assets/1504069/13577919/9c464192-e45a-11e5-88b8-19e741ab601b.png)
