### PR TITLE
Fixed bug in rules

### DIFF
--- a/lib/cuke_sniffer/rule_config.rb
+++ b/lib/cuke_sniffer/rule_config.rb
@@ -275,12 +275,12 @@ module CukeSniffer
         },
         :feature_same_tag => {
             :enabled => true,
-            :phrase => "Same tag appears on Feature.",
+            :phrase => "Same tag appears on both Feature and Scenario",
             :score => WARNING,
             :targets => ["Feature"],
             :reason => lambda { |feature, rule| if(feature.scenarios.count >= 2)
                           feature.scenarios[1..-1].each do |scenario|
-                            feature.scenarios.first.tags.each do |tag|
+                            feature.tags.each do |tag|
                               feature.store_rule(rule) if scenario.tags.include?(tag)
                             end
                           end

--- a/spec/cuke_sniffer/feature_spec.rb
+++ b/spec/cuke_sniffer/feature_spec.rb
@@ -319,6 +319,18 @@ describe "FeatureRules" do
     test_feature_rule(feature_block, :too_many_scenarios)
   end
 
+  it "should punish Features if all of the feature and any scenario have a common tag." do
+    feature_block = [
+      "@tag",
+      "Feature: I'm a feature with scenarios with identical tags!",
+      "",
+      "Scenario: I have the same tag1",
+      "@tag",
+      "Scenario: I have the same tag2"
+    ]
+    test_feature_rule(feature_block, :feature_same_tag)
+  end
+
   it "should punish Features if all of the scenarios have a common tag. Simple." do
     feature_block = [
         "Feature: I'm a feature with scenarios with identical tags!",
@@ -328,7 +340,7 @@ describe "FeatureRules" do
         "@tag",
         "Scenario: I have the same tag2"
     ]
-    test_feature_rule(feature_block, :feature_same_tag)
+    test_feature_rule(feature_block, :scenario_same_tag)
   end
 
   it "should punish Features if all of the scenarios have a common tag. Complex" do


### PR DESCRIPTION
This would raise a red herring if the first scenario shared any tags with subsequent scenarios.