### PR TITLE
Fixed bug in scenario check where all comments were flagged as commeted tags.

### DIFF
--- a/lib/cuke_sniffer/rule_config.rb
+++ b/lib/cuke_sniffer/rule_config.rb
@@ -315,7 +315,7 @@ module CukeSniffer
             :score => WARNING,
             :targets => ["Feature", "Scenario"],
             :reason => lambda { |feature_rule_target, rule| feature_rule_target.tags.each do | tag |
-                          feature_rule_target.store_rule(rule, rule.phrase.gsub("{class}", feature_rule_target.type)) if feature_rule_target.is_comment?(tag)
+                          feature_rule_target.store_rule(rule, rule.phrase.gsub("{class}", feature_rule_target.type)) if feature_rule_target.is_comment_and_tag?(tag)
                         end}
         },
         :empty_hook => {

--- a/lib/cuke_sniffer/rule_target.rb
+++ b/lib/cuke_sniffer/rule_target.rb
@@ -63,6 +63,10 @@ module CukeSniffer
       true if line =~ /^\#.*$/
     end
 
+    def is_comment_and_tag?(line)
+      true if line =~ /^\#.*\@.*$/
+    end
+
     def store_rule(rule, phrase = rule.phrase)
       @score += rule.score
       @rules_hash[phrase] ||= 0

--- a/spec/cuke_sniffer/scenario_spec.rb
+++ b/spec/cuke_sniffer/scenario_spec.rb
@@ -840,11 +840,20 @@ describe "ScenarioRules" do
 
   it "should punish Scenarios that have commented tags" do
     scenario_block = [
-        '#@tag',
-        "Scenario: Commented tag",
-        "Given I am a step"
+      '#@tag',
+      "Scenario: Commented tag",
+      "Given I am a step"
     ]
     test_scenario_rule(scenario_block, :commented_tag)
+  end
+
+  it "comments should not be punished as commented tags" do
+    scenario_block = [
+      '#blah',
+      "Scenario: Commented tag",
+      "Given I am a step"
+    ]
+    test_no_scenario_rule(scenario_block, :commented_tag)
   end
 
   it "should not punish Scenarios that have a comment before any tags occur" do


### PR DESCRIPTION
I noticed that it was complaining about "Commented Tags" in my results. Looks like this was due to comments directly above scenarios. While comments above scenarios aren't great, the mis-identification bothered me.
