### PR TITLE
Allow hooks in separate files in a hooks directory.

### DIFF
--- a/lib/cuke_sniffer/rule_config.rb
+++ b/lib/cuke_sniffer/rule_config.rb
@@ -472,7 +472,7 @@ module CukeSniffer
             :enabled => true,
             :phrase => "Hook found outside of the designated hooks file",
             :score => INFO,
-            :file => "hooks.rb",
+            :file => "hooks",
             :targets => ["Hook"],
             :reason => lambda { |hook, rule| hook.location.include?(rule.conditions[:file]) != true}
         },

--- a/spec/cuke_sniffer/hook_spec.rb
+++ b/spec/cuke_sniffer/hook_spec.rb
@@ -182,11 +182,20 @@ describe "HookRules" do
 
   it "should punish hooks that exist outside of the hooks.rb file" do
     hook_block = [
-        "Before do",
-        "end"
+      "Before do",
+      "end"
     ]
     @file_name = "env.rb"
     test_hook_rule(hook_block, :hook_not_in_hooks_file)
+  end
+
+  it "should not punish hooks that exist in a hooks directory" do
+    hook_block = [
+      "Before do",
+      "end"
+    ]
+    @file_name = "hooks/env.rb"
+    test_no_hook_rule(hook_block, :hook_not_in_hooks_file)
   end
 
   it "should punish Around hooks that do not have 2 parameters. 0 parameters." do


### PR DESCRIPTION
I've been working on a project that manages a large number of hooks (probably too many, but that's what happens when you test lots of configurations I guess). To manage this we split it up into several files under a hooks directory. I guess we could rename them to match type_hooks.rb and that would work, but I think a directory tree works out cleaner.

The major issue I see here is if you had a file that was like "captain_hooks_env.rb" that had hooks in it, I guess that would be confusing. But at the end of the day, I guess it's your repos so if you want to merge this feel free. I figured I'd offer some of these things separately in case you had other ideas/plans about how to address this sort of thing.
