### PR TITLE
junit output changed to relect jenkins/hudson xsd

### DIFF
--- a/spec/cuke_sniffer/formatter_spec.rb
+++ b/spec/cuke_sniffer/formatter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative '../spec_helper'
 require 'cuke_sniffer/formatter'
 
 describe CukeSniffer::Formatter do
@@ -271,11 +271,13 @@ describe CukeSniffer::Formatter do
       xml = CukeSniffer::Formatter.output_junit_xml(cuke_sniffer, @file_name)
 
       expect(xml).to match(/<testsuites/)
+      expect(xml).to match(/<testsuite/)
       expect(xml).to match(/tests="17"/)
       expect(xml).to match(/\.feature/)
       expect(xml).to match(/<failure .*type="failure"/)
       expect(xml).to match(/<failure .*message=/)
       expect(xml).to match(/<testcase classname=/)
+      expect(xml).to match(/<testsuite/)
       expect(xml).to match(/<\/testsuites>/)
       expect(xml).to match(/<\/testcase>/)
     end


### PR DESCRIPTION
Hi 
First of all i'd like to congratulate you on this gem and I hope you continue to develop it further. 
I have managed to integrate cuke_sniffer within Jenkins/Hudson but not without making changes to the junit output. The original junit builder collated all tests within a 'Testsuites' tag, which is rejected by jenkins. Testsuites should have a Testsuite and a Testsuite should have Testcases. I have changed the output to reflect this requirement. 
Each test was being produced as a Testsuite so I also collated test failures within the same file to produce a test suite. If a test has no failures then Jenkins/Hudson will read this as a passing result.
