### PR TITLE
Adding scenario line numbers to HTML report.

### DIFF
--- a/lib/cuke_sniffer/report/features.html.erb
+++ b/lib/cuke_sniffer/report/features.html.erb
@@ -104,7 +104,7 @@
                             <div class="btn btn-xs btn-default" style="display:none;"> <!--TODO enable this feature -->
                               View <span class="glyphicon glyphicon-eye-open"></span>
                             </div>
-                            <%= scenario.type %>: <%=scenario.name %>
+                            <%= scenario.type %>: <%=scenario.name %> (line: <%=scenario.start_line %>)
                           </div>
                           <div class="col-md-12 details well">
                             <% SummaryHelper::sort_improvement_list(scenario.rules_hash).each do |phrase, count| %>


### PR DESCRIPTION
Given that file line numbers are readily available in IDEs, it is often easier to find a scenario by its line number in a feature file rather than searching for it by name. This PR adds the line number next to a scenario's listing in the HTML report.