### PR TITLE
Introducing an enforcing of string

### DIFF
--- a/lib/cuke_sniffer/scenario.rb
+++ b/lib/cuke_sniffer/scenario.rb
@@ -158,7 +158,7 @@ module CukeSniffer
       index = 0
       while index < examples_section.size
         index += 2 if(examples_section[index].include?("Examples:"))
-        return_section << examples_section[index]
+        return_section << examples_section[index].to_s
         index += 1
       end
       return_section


### PR DESCRIPTION
`remove_examples_declaration` function follows a few bad code practices regarding working with indices. Playing with indices is by default prone to errors. Here we have stumbled upon the situation where the index is updated with +=2 and at the same time the examples_section has nothing at the index+2 underneath the `Examples:` therefore the examples_section[index] returns Nil instead of a String. One would argue that this is wrong cucumber formatting but since this is not currently crashing and it is executing ok, namely cucumber allows it, one shouldn't allow for the cuke_sniffer to crash either.